### PR TITLE
Support local settings

### DIFF
--- a/src/get-file-contents.ts
+++ b/src/get-file-contents.ts
@@ -1,0 +1,27 @@
+import { DangerDSLType } from "../node_modules/danger/distribution/dsl/DangerDSL"
+declare var danger: DangerDSLType
+declare function message(message: string): void
+declare function warn(message: string): void
+declare function fail(message: string): void
+declare function markdown(message: string): void
+declare function markdown(message: string): void
+
+const toMarkdownObject = (thing, title) => `
+## ${title}
+
+\`\`\`json
+${JSON.stringify(thing, null, "  ")}
+\`\`\`
+`
+
+const getFileContents = async (path: string, params: any) => {
+  const result = await danger.github.api.repos.getContent(params)
+  if (result) {
+    const buffer = new Buffer(result.data.content, "base64")
+    return buffer.toString()
+  } else {
+    fail(toMarkdownObject(params, "Network Error for " + path))
+  }
+}
+
+export default getFileContents

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,6 @@
-import {mdSpellCheck, spellCheck} from "./index"
+jest.mock("./get-file-contents", () => ({ default: jest.fn() }))
+import getFileContents from "./get-file-contents"
+import { getSpellcheckSettings, mdSpellCheck, spellCheck, SpellCheckJSONSettings } from "./index"
 
 declare const global: any
 beforeEach(() => {
@@ -6,7 +8,30 @@ beforeEach(() => {
   global.message = jest.fn()
   global.fail = jest.fn()
   global.markdown = jest.fn()
-  global.danger = { utils: { sentence: jest.fn()} , github: { utils: { fileLinks: jest.fn((f) => f.join(",")) }} }
+  global.danger = {
+    utils: {
+      sentence: jest.fn(),
+    },
+    github: {
+      utils: {
+        fileLinks: jest.fn(f => f.join(",")),
+      },
+      api: {
+        repos: {
+          getContent: jest.fn(),
+        },
+      },
+      pr: {
+        head: {
+          ref: "branch",
+        },
+      },
+    },
+    git: {
+      modified_files: ["README.md", "CHANGELOG.md"],
+      created_files: ["VISION.md"],
+    },
+  }
 })
 
 afterEach(() => {
@@ -15,6 +40,53 @@ afterEach(() => {
   global.fail = undefined
   global.markdown = undefined
   global.danger = undefined
+  getFileContents.mockReset()
+})
+
+describe("getSpellcheckSettings()", () => {
+  it("returns empty ignores and whitelist with no options", async () => {
+    getFileContents.mockImplementationOnce(() => Promise.resolve(""))
+
+    const settings = await getSpellcheckSettings()
+
+    expect(settings).toEqual({ ignore: [], whitelistFiles: [] })
+    expect(getFileContents).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns global settings with no local settings", async () => {
+    const globalSettings: SpellCheckJSONSettings = {
+      ignore: ["global"],
+      whitelistFiles: [],
+    }
+    getFileContents.mockImplementationOnce(() => Promise.resolve(JSON.stringify(globalSettings)))
+    getFileContents.mockImplementationOnce(() => Promise.resolve(""))
+
+    const something = { settings: "orta/my-settings@setting.json" }
+    const settings = await getSpellcheckSettings(something)
+
+    expect(settings).toEqual({ ignore: ["global"], whitelistFiles: [] })
+    expect(getFileContents).toHaveBeenCalledTimes(2)
+  })
+
+  it("returns local settings merged with global ones", async () => {
+    const globalSettings: SpellCheckJSONSettings = {
+      ignore: ["global"],
+      whitelistFiles: [],
+    }
+
+    const localSettings: SpellCheckJSONSettings = {
+      ignore: ["local"],
+      whitelistFiles: [],
+    }
+    getFileContents.mockImplementationOnce(() => Promise.resolve(JSON.stringify(globalSettings)))
+    getFileContents.mockImplementationOnce(() => Promise.resolve(JSON.stringify(localSettings)))
+
+    const something = { settings: "orta/my-settings@setting.json" }
+    const settings = await getSpellcheckSettings(something)
+
+    expect(settings).toEqual({ ignore: ["global", "local"], whitelistFiles: [] })
+    expect(getFileContents).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe("spellcheck()", () => {


### PR DESCRIPTION
This PR introduces the concept of a local `spellcheck.json` file so that individual repos can whitelist words that make sense for them.