### PR TITLE
Add abstraction of repo provider

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -236,11 +236,10 @@ export default async function spellcheck(options?: SpellCheckOptions) {
 
   // https://github.com/artsy/artsy-danger/edit/master/spellcheck.json
   if (hasTypos && (settings.hasLocalSettings || options)) {
-    const thisPR = repository.thisPR
     const repo = options && options.settings && githubRepresentationForPath(options.settings)
 
-    const repoEditURL = `/${thisPR.owner}/${thisPR.owner}/edit/${repository.headRef}/${implicitSettingsFilename}`
-    const globalEditURL = repo && `/${repo.owner}/${repo.repo}/edit/master/${repo.path}`
+    const repoEditURL = repository.editLink(implicitSettingsFilename, repository.headRef)
+    const globalEditURL = repo && repository.editLink(implicitSettingsFilename)
     const globalSlug = repo && repository.repoSlug
 
     let localMessage = ""

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,10 +132,13 @@ export const codeSpellCheck = (sourceText: string, path: string): Promise<SpellC
 
 export const githubRepresentationForPath = (value: string) => {
   if (value.includes("@")) {
+    const parts = value.split("@")
+    const slug = parts[0].split("/")
+
     return {
-      path: value.split("@")[1] as string,
-      owner: value.split("@")[0].split("/")[0] as string,
-      repo: value.split("@")[0].split("/")[1] as string,
+      path: parts[1],
+      owner: slug[0],
+      repo: slug[1],
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,8 +111,6 @@ const contextualErrorToMarkdown = (error: SpellCheckContext) => {
   return `${error.lineNumber} | ${sanitizedMarkdown}`
 }
 
-const getPRParams = path => ({ ...repository.thisPR, path, ref: repository.headRef })
-
 export const mdSpellCheck = (sourceText: string): SpellCheckWord[] =>
   mdspell.spell(sourceText, { ignoreNumbers: true, ignoreAcronyms: true })
 
@@ -178,8 +176,7 @@ export const getSpellcheckSettings = async (options?: SpellCheckOptions): Promis
     }
   }
 
-  const params = getPRParams(implicitSettingsFilename)
-  const localSettings = await parseSettingsFromFile(implicitSettingsFilename, `${params.owner}/${params.repo}`)
+  const localSettings = await parseSettingsFromFile(implicitSettingsFilename, repository.repoSlug)
   // from local settings file
   ignoredWords = ignoredWords.concat(localSettings.ignore)
   allowlistedMarkdowns = allowlistedMarkdowns.concat(localSettings.ignoreFiles)
@@ -222,8 +219,7 @@ export default async function spellcheck(options?: SpellCheckOptions) {
   for (const type of Object.keys(filesToLookAt)) {
     const files = filesToLookAt[type]
     for (const file of files) {
-      const params = getPRParams(file)
-      const contents = await repository.fileContents(params.path, `${params.owner}/${params.repo}`, params.ref)
+      const contents = await repository.fileContents(file, repository.repoSlug, repository.headRef)
       if (contents) {
         await spellCheck(file, contents, Number(type), ignoredWords, ignoredRegexes)
       }
@@ -245,7 +241,7 @@ export default async function spellcheck(options?: SpellCheckOptions) {
 
     const repoEditURL = `/${thisPR.owner}/${thisPR.owner}/edit/${repository.headRef}/${implicitSettingsFilename}`
     const globalEditURL = repo && `/${repo.owner}/${repo.repo}/edit/master/${repo.path}`
-    const globalSlug = repo && `${repo.owner}/${repo.repo}`
+    const globalSlug = repo && repository.repoSlug
 
     let localMessage = ""
     if (settings.hasLocalSettings && repoEditURL) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,7 @@ export const githubRepresentationForPath = (value: string) => {
 
     return {
       path: parts[1],
+      repoSlug: parts[0],
       owner: slug[0],
       repo: slug[1],
     }
@@ -170,10 +171,7 @@ export const getSpellcheckSettings = async (options?: SpellCheckOptions): Promis
   if (options && options.settings) {
     const settingsRepo = githubRepresentationForPath(options.settings)
     if (settingsRepo) {
-      const globalSettings = await parseSettingsFromFile(
-        settingsRepo.path,
-        `${settingsRepo.owner}/${settingsRepo.repo}`
-      )
+      const globalSettings = await parseSettingsFromFile(settingsRepo.path, settingsRepo.repoSlug)
       ignoredWords = ignoredWords.concat(globalSettings.ignore)
       allowlistedMarkdowns = allowlistedMarkdowns.concat(globalSettings.ignoreFiles)
     }

--- a/src/repository/github.ts
+++ b/src/repository/github.ts
@@ -3,6 +3,10 @@ import { GitHubDSL } from "danger"
 export class GitHubProvider {
   public constructor(private readonly api: GitHubDSL) {}
 
+  public get thisPR() {
+    return this.api.thisPR
+  }
+
   public fileLinks(paths: string[]) {
     return this.api.utils.fileLinks(paths)
   }

--- a/src/repository/github.ts
+++ b/src/repository/github.ts
@@ -2,4 +2,8 @@ import { GitHubDSL } from "danger"
 
 export class GitHubProvider {
   public constructor(private readonly api: GitHubDSL) {}
+
+  public fileLinks(paths: string[]) {
+    return this.api.utils.fileLinks(paths)
+  }
 }

--- a/src/repository/github.ts
+++ b/src/repository/github.ts
@@ -3,6 +3,11 @@ import { GitHubDSL } from "danger"
 export class GitHubProvider {
   public constructor(private readonly api: GitHubDSL) {}
 
+  public get repoSlug() {
+    const pr = this.api.thisPR
+    return `${pr.owner}/${pr.repo}`
+  }
+
   public get thisPR() {
     return this.api.thisPR
   }

--- a/src/repository/github.ts
+++ b/src/repository/github.ts
@@ -7,6 +7,10 @@ export class GitHubProvider {
     return this.api.thisPR
   }
 
+  public get headRef() {
+    return this.api.pr.head.ref
+  }
+
   public fileLinks(paths: string[]) {
     return this.api.utils.fileLinks(paths)
   }

--- a/src/repository/github.ts
+++ b/src/repository/github.ts
@@ -8,10 +8,6 @@ export class GitHubProvider {
     return `${pr.owner}/${pr.repo}`
   }
 
-  public get thisPR() {
-    return this.api.thisPR
-  }
-
   public get headRef() {
     return this.api.pr.head.ref
   }

--- a/src/repository/github.ts
+++ b/src/repository/github.ts
@@ -16,6 +16,10 @@ export class GitHubProvider {
     return this.api.pr.head.ref
   }
 
+  public editLink(fileName: string, ref = "master") {
+    return `/${this.repoSlug}/edit/${ref}/${fileName}`
+  }
+
   public fileLinks(paths: string[]) {
     return this.api.utils.fileLinks(paths)
   }

--- a/src/repository/github.ts
+++ b/src/repository/github.ts
@@ -1,0 +1,5 @@
+import { GitHubDSL } from "danger"
+
+export class GitHubProvider {
+  public constructor(private readonly api: GitHubDSL) {}
+}

--- a/src/repository/github.ts
+++ b/src/repository/github.ts
@@ -6,4 +6,8 @@ export class GitHubProvider {
   public fileLinks(paths: string[]) {
     return this.api.utils.fileLinks(paths)
   }
+
+  public async fileContents(path: string, repoSlug?: string, ref?: string) {
+    return this.api.utils.fileContents(path, repoSlug, ref)
+  }
 }

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -1,0 +1,13 @@
+import { DangerDSL } from "danger/distribution/dsl/DangerDSL"
+import { GitHubProvider } from "./github"
+
+/**
+ * Get repository based if danger.github, or any other danger.<provider> exists
+ */
+export const getRepository = (danger: DangerDSL) => {
+  if (danger.github) {
+    return new GitHubProvider(danger.github)
+  }
+
+  throw new Error("Unsupported provider")
+}


### PR DESCRIPTION
Addresses: https://github.com/orta/danger-plugin-spellcheck/issues/29

Abstracts GitHub provider for now, API methods created based on currently detected usage.

API:

```ts
const repository = getRepository(danger)

repository.repoSlug;
repostiory.headRef;
repostiory.editLink(fileName: string, ref = "master");
repostiory.fileLinks(paths: string[]);
async repostiory.fileContents(path: string, repoSlug?: string, ref?: string)
```